### PR TITLE
Avoid memory corruption

### DIFF
--- a/FCollada/FUtils/FUBoundingBox.cpp
+++ b/FCollada/FUtils/FUBoundingBox.cpp
@@ -126,7 +126,7 @@ FUBoundingBox FUBoundingBox::Transform(const FMMatrix44& transform) const
 		FMVector3(maximum.x, minimum.y, minimum.z), FMVector3(maximum.x, minimum.y, maximum.z)
 	};
 
-	for (size_t i = 0; i < 6; ++i)
+	for (size_t i = 0; i < 3; ++i)
 	{
 		testPoints[i] = transform.TransformCoordinate(testPoints[i]);
 		transformedBoundingBox.Include(testPoints[i]);


### PR DESCRIPTION
- don't iterate over 6 testPoints and write back to them, when you only have 3